### PR TITLE
Switch to fixed do solfège and add roman numerals

### DIFF
--- a/aurebesh.js
+++ b/aurebesh.js
@@ -68,6 +68,7 @@ var alphabets = {
   'SPACE': '_',
   'Solfège': 'Do,Re,Mi,Fa,Sol,La,Si',
   'XXX': 'xX',
+  'Roman': 'IVXLCDM',
   'Kannada': 'ಠಉನಊಝಏೡಖತ',
   'Tifinagh': 'ⴼⵊⵏⵂⵗⵓⴻⵐⵜ',
   'Vai': 'ꔀꕐꖠꔢꖈꖕꔈꔉꔁ',

--- a/aurebesh.js
+++ b/aurebesh.js
@@ -66,7 +66,7 @@ var alphabets = {
   'ooo': 'òŏôǒöőõȯōȍ',
   'Deutsch': 'Ä,ja,nein,ö,Ü,sch,Schnitzel,Bier,ß',
   'SPACE': '_',
-  'Solfège': 'Do,Re,Mi,Fa,Sol,La,Ti',
+  'Solfège': 'Do,Re,Mi,Fa,Sol,La,Si',
   'XXX': 'xX',
   'Kannada': 'ಠಉನಊಝಏೡಖತ',
   'Tifinagh': 'ⴼⵊⵏⵂⵗⵓⴻⵐⵜ',


### PR DESCRIPTION
Hi @aemkei, thanks for this very cool project that I re-discovered today!

I would like to propose two modest contributions:

- Switching to [fixed do solfège](https://en.wikipedia.org/wiki/Solf%C3%A8ge#Fixed_do_solf.C3.A8ge) by renaming Ti to Si: I'm biased, because I studied solfège and music for 12 years in France, but I believe fixed do is the right way to go here. @mxfh, since you originally contributed Solfège, please have a look.

- Adding roman numerals: This doesn't make much sense semantically, but I find the results interesting visually. (Side-note: I've had some [fun](https://github.com/jankeromnes/roman/blob/master/roman.js) with roman numeral conversion before. I'd love to golf the code one day, and maybe use aurebesh to translate it into "roman numerals". That'd be fun!)

I was also tempted to add Tengwar, Tolkien's Elvish script, but even if it's being included in the Unicode standard and there are several fonts out there, it seems we're [not quite there yet](https://en.wikipedia.org/wiki/Tengwar#Encoding_schemes). Maybe using web fonts can help bridge this gap, but I didn't find any useful google web font for this.